### PR TITLE
Update atom.json

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -15,7 +15,7 @@
         }
     },
     "bin": [
-        "atom.exe",
+        "\\resources\\cli\\atom.cmd",
         "\\resources\\app\\apm\\bin\\apm.cmd"
     ],
     "shortcuts": [


### PR DESCRIPTION
Changed bin from atom.exe to atom.cmd
Here's why: https://discuss.atom.io/t/windows-7-starting-atom-exe-from-command-line/18571